### PR TITLE
[FIX] Linkedin normalization

### DIFF
--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -1,7 +1,9 @@
 class Mentor < ApplicationRecord
   normalizes :name, with: ->(n) { n.strip.downcase.gsub(/\s+/, " ").titleize }
   normalizes :email, with: ->(e) { e.strip.downcase.gsub(/\s+/, "") }
-  normalizes :linkedin_url, with: ->(url) { url.strip.downcase.gsub(/\s+/, "") }
+  normalizes :linkedin_url, with: ->(url) {
+  url.blank? ? nil : url.strip.downcase.gsub(/\s+/, "")
+}
   normalizes :mentorship_topics, with: ->(topics) {
     topics.to_s.split(",").map { |t| t.strip.downcase.gsub(/\s+/, " ") }.join(",")
   }

--- a/app/views/mentors/_mentor.html.erb
+++ b/app/views/mentors/_mentor.html.erb
@@ -21,7 +21,11 @@
 
   <p>
     <strong>Redes sociais:</strong>
-    <td><%= link_to "LinkedIn", safe_url(mentor.linkedin_url), target: "_blank", rel: "noopener" %></td>
+      <% if mentor.linkedin_url.present? %>
+    <td>
+    <%= link_to "LinkedIn", safe_url(mentor.linkedin_url), target: "_blank", rel: "noopener" %>
+    </td>
+      <% end %>
   </p>
 
   <p>

--- a/app/views/mentors/index.html.erb
+++ b/app/views/mentors/index.html.erb
@@ -21,7 +21,11 @@
       <tr>
         <td><%= mentor.name %></td>
         <td><%= mail_to mentor.email, target: "_blank" %></td>
-        <td><%= link_to "LinkedIn", safe_url(mentor.linkedin_url), target: "_blank", rel: "noopener" %></td>
+        <td>
+        <% if mentor.linkedin_url.present? %>
+        <%= link_to "LinkedIn", safe_url(mentor.linkedin_url), target: "_blank", rel: "noopener" %>
+        <% end %>
+        </td>
         <td><%= format_mentorship_topics(mentor.mentorship_topics) %></td>
         <td><%= link_to "Mostrar mais", mentor %></td>
       </tr>

--- a/spec/models/mentor_spec.rb
+++ b/spec/models/mentor_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Mentor, type: :model do
   [
     { input: "linkedin.com/mentorax", expected: "linkedin.com/mentorax", desc: "already formatted" },
     { input: "  linkedin   .com/ mentorax  ", expected: "linkedin.com/mentorax", desc: "extra spaces" },
-    { input: "liNKEDin .COM/mentoraX", expected: "linkedin.com/mentorax", desc: "upcased" }
+    { input: "liNKEDin .COM/mentoraX", expected: "linkedin.com/mentorax", desc: "upcased" },
+    { input: "", expected: nil, desc: "blank input becomes nil" }
   ].each do |tc|
     it "normalizes linkedin url: #{tc[:desc]}" do
       mentor = described_class.new(linkedin_url: tc[:input])


### PR DESCRIPTION
Corrige o comportamento inesperado no campo `linkedin_url `no formulário de criação/edição de mentoras.

Anteriormente, ao deixar o campo em branco e submeter o formulário, a normalização acabava tratando a URL como uma string vazia, o que fazia com que o Rails interpretasse como uma relative path, preenchendo o campo com a URL atual.

Com isso, ajustei a normalização do campo `linkedin_url `para garantir que, quando o campo for deixado em branco, ele seja transformado em `nil`, evitando preenchimentos automáticos indesejados.